### PR TITLE
Update latest buffer version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "events": "~1.1.0",
     "util": "~0.10.3",
     "assert": "~1.3.0",
-    "buffer": "~4.3.0",
+    "buffer": "~5.0.6",
     "punycode": "~1.4.0",
     "url": "~0.11.0",
     "domain-browser": "~1.1.7",


### PR DESCRIPTION
Buffer.alloc() is used across various packages and older version of buffer does not support .alloc. Updating the version will fix the issue.
FYI. Already exiting issues with Buffer.alloc with other build tools. [https://github.com/crypto-browserify/createHmac/issues/20](url)